### PR TITLE
fix: separate auth0 errors

### DIFF
--- a/cmd/comms/coordinator/main.go
+++ b/cmd/comms/coordinator/main.go
@@ -44,7 +44,7 @@ func main() {
 		CoordinatorURL: conf.CoordinatorURL,
 		Secret:         conf.Coordinator.ServerSecret,
 		RequestTTL:     conf.Coordinator.AuthTTL,
-		Log: log,
+		Log:            log,
 	})
 
 	if err != nil {

--- a/cmd/comms/server/main.go
+++ b/cmd/comms/server/main.go
@@ -35,7 +35,7 @@ func main() {
 		IdentityURL: conf.IdentityURL,
 		Secret:      conf.CommServer.ServerSecret,
 		RequestTTL:  conf.CommServer.AuthTTL,
-		Log: log,
+		Log:         log,
 	})
 
 	if err != nil {

--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -23,12 +23,12 @@ type rootConfig struct {
 		Domain string `overwrite-flag:"auth0Domain"`
 	}
 	Identity struct {
-		PublicURL       string `overwrite-flag:"publicURL" validate:"required"`
-		Host            string `overwrite-flag:"host"      flag-usage:"host name" validate:"required"`
-		Port            int    `overwrite-flag:"port"      flag-usage:"host port" validate:"required"`
-		LogLevel        string `overwrite-flag:"logLevel"`
-		ClientsDataPath string `overwrite-flag:"clientsDataPath"`
-		PrivateKeyPath  string `overwrite-flag:"privateKeyPath" validate:"required"`
+		PublicURL       string        `overwrite-flag:"publicURL" validate:"required"`
+		Host            string        `overwrite-flag:"host"      flag-usage:"host name" validate:"required"`
+		Port            int           `overwrite-flag:"port"      flag-usage:"host port" validate:"required"`
+		LogLevel        string        `overwrite-flag:"logLevel"`
+		ClientsDataPath string        `overwrite-flag:"clientsDataPath"`
+		PrivateKeyPath  string        `overwrite-flag:"privateKeyPath" validate:"required"`
 		JwtDuration     time.Duration `overwrite-flag:"tokenDuration" validate:"required" flag-usage:"access token duration in seconds"`
 		Metrics         struct {
 			Enabled   bool   `overwrite-flag:"metrics" flag-usage:"enable metrics"`

--- a/internal/commons/auth/comms.go
+++ b/internal/commons/auth/comms.go
@@ -118,7 +118,7 @@ func (a *Authenticator) AuthenticateFromURL(role brokerProtocol.Role, r *http.Re
 
 		content := fmt.Sprintf("GET:%s", a.connectURL)
 		req := auth2.AuthRequest{Credentials: credentials, Content: []byte(content)}
-		ok, err :=  a.provider.ApproveRequest(&req)
+		ok, err := a.provider.ApproveRequest(&req)
 		if err != nil {
 			a.log.WithError(err).Error("failed to validate request")
 		}

--- a/internal/commons/auth/comms.go
+++ b/internal/commons/auth/comms.go
@@ -2,10 +2,11 @@ package auth
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"path"
+
+	"github.com/sirupsen/logrus"
 
 	auth2 "github.com/decentraland/auth-go/pkg/auth"
 	brokerProtocol "github.com/decentraland/webrtc-broker/pkg/protocol"

--- a/internal/identity/data/auth0.go
+++ b/internal/identity/data/auth0.go
@@ -92,7 +92,6 @@ func (s *Auth0Service) GetUserInfo(accessToken string) (User, error) {
 	return user, Auth0ValidationError{msg}
 }
 
-
 type Auth0UnexpectedError struct {
 	Cause string
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -4,12 +4,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/decentraland/world/internal/commons/auth"
-	"github.com/decentraland/world/internal/commons/utils"
-	"github.com/decentraland/world/internal/commons/version"
 	"net/http"
 	"path"
 	"strings"
+
+	"github.com/decentraland/world/internal/commons/auth"
+	"github.com/decentraland/world/internal/commons/utils"
+	"github.com/decentraland/world/internal/commons/version"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
We were treating all errors coming from auth0 as an "unauthorized" call, which is a mistake. The idea is to differentiate token validations errors from other type of errors that might occur when calling Auht0 API.

+ Format code
+ Imports